### PR TITLE
MUO upgrade issue fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func main() {
 		LeaderElectionID:       "312e6264.managed.openshift.io",
 		SyncPeriod:             &syncPeriod,
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+			options.Cache = nil
 			return client.New(config, options)
 		},
 	})


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?

While commencing upgrade MUO shows error after updating k8s service to version 0.27.2 and CR 0.15.0
`ts=2023-07-28T05:47:17.052483999Z level=error msg="Reconciler error" controller=upgradeconfig controllerGroup=upgrade.managed.openshift.io controllerKind=UpgradeConfig UpgradeConfig="{managed-upgrade-config test-managed-upgrade-operator}" namespace=test-managed-upgrade-operator name=managed-upgrade-config reconcileID=6f7bc8e9-4e3a-4713-a91d-691971cf379c error="Service \"prometheus-k8s\" not found" stacktrace="sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller`

To resolve this, we need to clear cache when setting controller manager.  

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-17455

### Pre-checks (if applicable):

- [x] Tested latest changes against a cluster by replicating bug

